### PR TITLE
Removed findGameBy_Location method from GameRepository.java

### DIFF
--- a/src/main/java/com/keyin/rest/game/GameRepository.java
+++ b/src/main/java/com/keyin/rest/game/GameRepository.java
@@ -7,5 +7,4 @@ import java.util.List;
 
 @Repository
 public interface GameRepository extends CrudRepository<Game, Long> {
-    public List<Game> findByGame_Location(String location);
 }


### PR DESCRIPTION
- Removed findGameBy_Location method from GameRepository.java
- - If a repository method is not in use, the program does not start. Duly noted.